### PR TITLE
Enable package to load model from local path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 result*
 weights*
 .vscode
+.pypirc
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/craft_text_detector/__init__.py
+++ b/craft_text_detector/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import os
+from typing import Optional
 
 import craft_text_detector.craft_utils as craft_utils
 import craft_text_detector.file_utils as file_utils
@@ -44,6 +45,8 @@ class Craft:
         long_size=1280,
         refiner=True,
         crop_type="poly",
+        weight_path_craft_net: Optional[str] = None,
+        weight_path_refine_net: Optional[str] = None,
     ):
         """
         Arguments:
@@ -72,22 +75,22 @@ class Craft:
         self.crop_type = crop_type
 
         # load craftnet
-        self.load_craftnet_model()
+        self.load_craftnet_model(weight_path_craft_net)
         # load refinernet if required
         if refiner:
-            self.load_refinenet_model()
+            self.load_refinenet_model(weight_path_refine_net)
 
-    def load_craftnet_model(self):
+    def load_craftnet_model(self, weight_path: Optional[str] = None):
         """
         Loads craftnet model
         """
-        self.craft_net = load_craftnet_model(self.cuda)
+        self.craft_net = load_craftnet_model(self.cuda, weight_path=weight_path)
 
-    def load_refinenet_model(self):
+    def load_refinenet_model(self, weight_path: Optional[str] = None):
         """
         Loads refinenet model
         """
-        self.refine_net = load_refinenet_model(self.cuda)
+        self.refine_net = load_refinenet_model(self.cuda, weight_path=weight_path)
 
     def unload_craftnet_model(self):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 torch>=1.6.0
 torchvision>=0.7.0
-opencv-python>=3.4.8.29
+opencv-python-headless>=3.4.8.29
 scipy>=1.3.2
 gdown>=3.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 torch>=1.6.0
 torchvision>=0.7.0
-opencv-python-headless>=3.4.8.29,<4.5.4.62
+opencv-python>=3.4.8.29,<4.5.4.62
 scipy>=1.3.2
 gdown>=3.10.1


### PR DESCRIPTION
When using the pypi package it should be allowed to use a model from a local path, because loading it from a remote location removes the control over what model is currently used. And might also result in pull limits being reached.